### PR TITLE
Create Discriminated Unions from Sealed traits

### DIFF
--- a/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
+++ b/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
@@ -16,7 +16,7 @@ private class Macros(val c: blackbox.Context) {
 
   private def caseClassFieldsTypes(T: Type): ListMap[String, Type] = {
     val paramLists = primaryConstructor(T).paramLists
-    val params = paramLists.head
+    val params     = paramLists.head
 
     if (paramLists.size > 1)
       c.error(c.enclosingPosition, s"Only one parameter list classes are supported. Found: $T")
@@ -34,8 +34,8 @@ private class Macros(val c: blackbox.Context) {
     }: _*)
   }
 
-  def generateInterface[T: c.WeakTypeTag]: Tree = {
-    val T = c.weakTypeOf[T]
+  def generateInterfaceFromCaseClass[T: c.WeakTypeTag]: Tree = {
+    val T      = c.weakTypeOf[T]
     val symbol = getClassSymbol(T)
 
     if (!symbol.isCaseClass)
@@ -66,4 +66,6 @@ private class Macros(val c: blackbox.Context) {
 
   protected def isCaseClass(tpe: Type): Boolean =
     tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass
+
+  def generateTypeFromCaseClass[T: c.WeakTypeTag]: Tree = ???
 }

--- a/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
+++ b/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
@@ -74,9 +74,7 @@ private class Macros(val c: blackbox.Context) {
     val children = symbol.knownDirectSubclasses.toSeq
 
     val operands = children map { symbol =>
-      val tpe = symbol.asType
-      // use .serialize so TSInterface("XXX", ... ) becomes "XXX", and TSNumber becomes "number" etc
-      q"TypescriptType.nameOrType(implicitly[TSType[$tpe]].get)"
+      q"TypescriptType.nameOrType(implicitly[TSType[${symbol.asType}]].get)"
     }
 
     q"""{

--- a/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
+++ b/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
@@ -10,7 +10,7 @@ private class Macros(val c: blackbox.Context) {
     T.decls.collectFirst {
       case m: MethodSymbol if m.isPrimaryConstructor =>
         if (!m.isPublic)
-          c.error(c.enclosingPosition, s"Only classes with public primary constructor are supported. Found: $T")
+          c.abort(c.enclosingPosition, s"Only classes with public primary constructor are supported. Found: $T")
         m
     }.get
 
@@ -19,11 +19,11 @@ private class Macros(val c: blackbox.Context) {
     val params     = paramLists.head
 
     if (paramLists.size > 1)
-      c.error(c.enclosingPosition, s"Only one parameter list classes are supported. Found: $T")
+      c.abort(c.enclosingPosition, s"Only one parameter list classes are supported. Found: $T")
 
     params.foreach { p =>
       if (!p.isPublic)
-        c.error(
+        c.abort(
           c.enclosingPosition,
           s"Only classes with all public constructor arguments are supported. Found: $T"
         )
@@ -36,38 +36,54 @@ private class Macros(val c: blackbox.Context) {
 
   def generateInterfaceFromCaseClass[T: c.WeakTypeTag]: Tree = {
     val T      = c.weakTypeOf[T]
-    val symbol = getClassSymbol(T)
+    val symbol = getClassOrTraitSymbol(T)
 
     if (!symbol.isCaseClass)
-      c.error(c.enclosingPosition, s"Expected case class, but found: $T")
+      c.abort(c.enclosingPosition, s"Expected case class, but found: $T")
 
     val members = caseClassFieldsTypes(T) map {
       case (name, optional) if optional <:< typeOf[Option[_]] =>
         val typeArg = optional.typeArgs.head
-        q"($name, TSUnion.of(implicitly[TSType[$typeArg]].get, TSUndefined))"
+        q"($name, implicitly[TSType[$typeArg]] | TSUndefined)"
       case (name, tpe) =>
         q"($name, implicitly[TSType[$tpe]].get)"
     }
 
     q"""{
-       import nl.codestar.scalatsi.TypescriptType._
-       import nl.codestar.scalatsi.{ TSNamedType, TSIType }
+       import nl.codestar.scalatsi.TypescriptType.TSUndefined
+       import nl.codestar.scalatsi.{TSNamedType, TSIType}
        import scala.collection.immutable.ListMap
        TSIType(TSInterface("I" + ${symbol.name.toString}, ListMap(..$members)))
       }"""
   }
 
-  private def getClassSymbol(T: Type): ClassSymbol = {
+  private def getClassOrTraitSymbol(T: Type): ClassSymbol = {
     val symbol = T.typeSymbol
     if (!symbol.isClass)
-      c.error(c.enclosingPosition, s"Expected class, but found $T")
+      c.abort(c.enclosingPosition, s"Expected class or trait, but found $T")
     symbol.asClass
   }
 
-  protected def isCaseClass(tpe: Type): Boolean =
-    tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass
-
   def generateUnionFromSealedTrait[T: c.WeakTypeTag]: Tree = {
-    ???
+    val T      = c.weakTypeOf[T]
+    val symbol = getClassOrTraitSymbol(T)
+
+    if (!symbol.isSealed)
+      c.error(c.enclosingPosition, s"Expected sealed trait or class, but found: $T")
+
+    val children = symbol.knownDirectSubclasses.toSeq
+
+    val operands = children map { symbol =>
+      val tpe = symbol.asType
+      // use .serialize so TSInterface("XXX", ... ) becomes "XXX", and TSNumber becomes "number" etc
+      q"TSTypeReference(TypescriptTypeSerializer.serialize(implicitly[TSType[$tpe]].get))"
+    }
+
+    q"""{
+       import nl.codestar.scalatsi.TypescriptType.{TSAlias, TSUnion}
+       import nl.codestar.scalatsi.{ TSNamedType, TSIType }
+       import scala.collection.immutable.Vector
+       TSNamedType(TSAlias(${symbol.name.toString}, TSUnion(Vector(..$operands))))
+      }"""
   }
 }

--- a/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
+++ b/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
@@ -76,12 +76,12 @@ private class Macros(val c: blackbox.Context) {
     val operands = children map { symbol =>
       val tpe = symbol.asType
       // use .serialize so TSInterface("XXX", ... ) becomes "XXX", and TSNumber becomes "number" etc
-      q"TSTypeReference(TypescriptTypeSerializer.serialize(implicitly[TSType[$tpe]].get))"
+      q"TypescriptType.nameOrType(implicitly[TSType[$tpe]].get)"
     }
 
     q"""{
        import nl.codestar.scalatsi.TypescriptType.{TSAlias, TSUnion}
-       import nl.codestar.scalatsi.{ TSNamedType, TSIType }
+       import nl.codestar.scalatsi.TypescriptType
        import scala.collection.immutable.Vector
        TSNamedType(TSAlias(${symbol.name.toString}, TSUnion(Vector(..$operands))))
       }"""

--- a/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
+++ b/macros/src/main/scala/nl/codestar/scalatsi/Macros.scala
@@ -67,5 +67,7 @@ private class Macros(val c: blackbox.Context) {
   protected def isCaseClass(tpe: Type): Boolean =
     tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass
 
-  def generateTypeFromCaseClass[T: c.WeakTypeTag]: Tree = ???
+  def generateUnionFromSealedTrait[T: c.WeakTypeTag]: Tree = {
+    ???
+  }
 }

--- a/src/main/scala/nl/codestar/scalatsi/TSType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TSType.scala
@@ -40,7 +40,9 @@ object TSType {
   def apply[T](tt: TypescriptType): TSType[T] = new TSTypeImpl(tt)
 
   /** Generate a typescript interface for a case class */
-  def fromCaseClass[T]: TSIType[T] = macro Macros.generateInterface[T]
+  def fromCaseClass[T]: TSIType[T] = macro Macros.generateInterfaceFromCaseClass[T]
+
+  def fromSealedTrait[T]: TSNamedType[T] = macro Macros.generateTypeFromCaseClass[T]
 
   /** Uses the typescript type of Target whenever we're looking for the typescript type of Source
     * This will not generate a `type Source = Target` line like alias

--- a/src/main/scala/nl/codestar/scalatsi/TSType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TSType.scala
@@ -61,7 +61,7 @@ object TSType {
     *
     * @see [Typescript docs on Discrimintated Unions](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions)
     **/
-  def fromSealedTrait[T]: TSNamedType[T] = macro Macros.generateUnionFromSealedTrait[T]
+  def fromSealed[T]: TSNamedType[T] = macro Macros.generateUnionFromSealedTrait[T]
 
   /** Uses the typescript type of Target whenever we're looking for the typescript type of Source
     * This will not generate a `type Source = Target` line like alias
@@ -96,7 +96,7 @@ object TSType {
     */
   def external[T](name: String): TSNamedType[T] =
     TypescriptType.fromString(name) match {
-      case t: TSExternalName => TSNamedType(t)
+      case t: TSTypeReference => TSNamedType(t)
       case t =>
         throw new IllegalArgumentException(s"String $name is a predefined type $t")
     }

--- a/src/main/scala/nl/codestar/scalatsi/TSType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TSType.scala
@@ -42,7 +42,26 @@ object TSType {
   /** Generate a typescript interface for a case class */
   def fromCaseClass[T]: TSIType[T] = macro Macros.generateInterfaceFromCaseClass[T]
 
-  def fromSealedTrait[T]: TSNamedType[T] = macro Macros.generateTypeFromCaseClass[T]
+  /** Generate a Typescript discriminated union from a scala sealed trait
+    * @example
+    * ```
+    * sealed trait AorB
+    * case class A(foo: Int) extends AorB
+    * case class B(bar: Int) extends AorB
+    *
+    * implicit val tsA = ...
+    * implicit val tsB = ...
+    *
+    * implicit val tsAorB = TSType.fromSealedTrait[AorB]
+    * ```
+    *
+    * wil produce
+    *
+    * `type AorB = A | B`
+    *
+    * @see [Typescript docs on Discrimintated Unions](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions)
+    **/
+  def fromSealedTrait[T]: TSNamedType[T] = macro Macros.generateUnionFromSealedTrait[T]
 
   /** Uses the typescript type of Target whenever we're looking for the typescript type of Source
     * This will not generate a `type Source = Target` line like alias

--- a/src/main/scala/nl/codestar/scalatsi/TSType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TSType.scala
@@ -49,10 +49,7 @@ object TSType {
     * case class A(foo: Int) extends AorB
     * case class B(bar: Int) extends AorB
     *
-    * implicit val tsA = ...
-    * implicit val tsB = ...
-    *
-    * implicit val tsAorB = TSType.fromSealedTrait[AorB]
+    * implicit val tsAorB = TSType.fromSealed[AorB]
     * ```
     *
     * wil produce

--- a/src/main/scala/nl/codestar/scalatsi/TypescriptType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TypescriptType.scala
@@ -29,10 +29,18 @@ object TypescriptType {
       case _           => TSTypeReference(tpe)
     }
 
+  /** Get a reference to a named type, or the type itself if it is unnamed or builtin */
+  def nameOrType(tpe: TypescriptType): TypescriptType = tpe match {
+    case named: TypescriptNamedType => named.asReference
+    case anonymous                  => anonymous
+  }
+
   /** A marker trait for a TS type that has a name */
   sealed trait TypescriptNamedType extends TypescriptType {
     def name: String
     require(isValidTSName(name), s"Not a valid TypeScript identifier: $name")
+
+    def asReference: TSTypeReference = TSTypeReference(name)
   }
   object TypescriptNamedType
 
@@ -74,7 +82,9 @@ object TypescriptType {
     * this type is used as a marker that a type with this name exists and is either already defined or externally defined
     * @note name takes from [Typescript specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.8.2)
     * */
-  case class TSTypeReference(name: String) extends TypescriptNamedType
+  case class TSTypeReference(name: String) extends TypescriptNamedType {
+    override def asReference: TSTypeReference = this
+  }
 
   /** Typescript indexed interfaces
     * { [indexName:indexType]: valueType}

--- a/src/main/scala/nl/codestar/scalatsi/TypescriptType.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TypescriptType.scala
@@ -29,7 +29,7 @@ object TypescriptType {
       case _           => TSTypeReference(tpe)
     }
 
-  /** Get a reference to a named type, or the type itself if it is unnamed or builtin */
+  /** Get a reference to a named type, or the type itself if it is unnamed or built-in */
   def nameOrType(tpe: TypescriptType): TypescriptType = tpe match {
     case named: TypescriptNamedType => named.asReference
     case anonymous                  => anonymous
@@ -58,14 +58,9 @@ object TypescriptType {
     override def nested: Set[TypescriptType] = Set(underlying)
   }
 
-  /** Typescript `any` */
-  case object TSAny extends TypescriptType
-
-  /** Typscript array: `elementType[]` */
+  case object TSAny                               extends TypescriptType
   case class TSArray(elementType: TypescriptType) extends TypescriptAggregateType { def nested: Set[TypescriptType] = Set(elementType) }
-
-  /** Typescript `boolean` */
-  case object TSBoolean extends TypescriptType
+  case object TSBoolean                           extends TypescriptType
 
   sealed trait TSLiteralType[T]                 extends TypescriptType { val value: T }
   case class TSLiteralString(value: String)     extends TSLiteralType[String]
@@ -78,8 +73,8 @@ object TypescriptType {
     def nested: Set[TypescriptType] = Set(TSNumber)
   }
 
-  /** Not really a typescript type,
-    * this type is used as a marker that a type with this name exists and is either already defined or externally defined
+  /** This type is used as a marker that a type with this name exists and is either already defined or externally defined
+    * Not a real Typescript type
     * @note name takes from [Typescript specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.8.2)
     * */
   case class TSTypeReference(name: String) extends TypescriptNamedType {
@@ -108,13 +103,6 @@ object TypescriptType {
     def nested: Set[TypescriptType] = Set(indexType, valueType)
   }
 
-  /** Typescript interface
-    * ```
-    * interface name {
-    *    member.name: member.type
-    * }
-    * ```
-    */
   case class TSInterface(name: String, members: ListMap[String, TypescriptType]) extends TypescriptNamedType with TypescriptAggregateType {
     def nested: Set[TypescriptType] = members.values.toSet
   }
@@ -128,7 +116,7 @@ object TypescriptType {
   case object TSObject extends TypescriptType
   case object TSString extends TypescriptType
 
-  /** Typescript tuple: `[0.type, 1.type, ... n.type]`*/
+  /** Typescript tuple: `[0.type, 1.type, ... n.type]` */
   case class TSTuple[E](of: Seq[TypescriptType]) extends TypescriptAggregateType { def nested: Set[TypescriptType] = of.toSet }
   object TSTuple {
     def of(of: TypescriptType*) = TSTuple(of)

--- a/src/main/scala/nl/codestar/scalatsi/TypescriptTypeSerializer.scala
+++ b/src/main/scala/nl/codestar/scalatsi/TypescriptTypeSerializer.scala
@@ -64,7 +64,7 @@ object TypescriptTypeSerializer {
          |}
        """.stripMargin
 
-    case _: TSExternalName => ""
+    case _: TSTypeReference => ""
 
     case TSInterfaceIndexed(name, indexName, indexType, valueType) =>
       s"""export interface $name {

--- a/src/main/scala/nl/codestar/scalatsi/dsl/package.scala
+++ b/src/main/scala/nl/codestar/scalatsi/dsl/package.scala
@@ -29,6 +29,8 @@ package object dsl {
   implicit class TSInterfaceDSL(val interface: TSInterface) extends AnyVal {
     def +(member: (String, TypescriptType)): TSInterface =
       interface.copy(members = interface.members + member)
+    def +(member: (String, String)): TSInterface =
+      interface + (member._1 -> TSLiteralString(member._2))
     def ++(newMembers: Iterable[(String, TypescriptType)]): TSInterface =
       interface.copy(members = interface.members ++ newMembers)
     def -(member: String): TSInterface =
@@ -39,6 +41,8 @@ package object dsl {
 
   implicit class TSITypeDSL[T](val tsiType: TSIType[T]) extends AnyVal {
     def +(member: (String, TypescriptType)): TSIType[T] =
+      TSIType(tsiType.get + member)
+    def +(member: (String, String)): TSIType[T] =
       TSIType(tsiType.get + member)
     def ++(newMembers: Seq[(String, TypescriptType)]): TSIType[T] =
       TSIType(tsiType.get ++ newMembers)

--- a/src/main/scala/nl/codestar/scalatsi/dsl/package.scala
+++ b/src/main/scala/nl/codestar/scalatsi/dsl/package.scala
@@ -29,8 +29,6 @@ package object dsl {
   implicit class TSInterfaceDSL(val interface: TSInterface) extends AnyVal {
     def +(member: (String, TypescriptType)): TSInterface =
       interface.copy(members = interface.members + member)
-    def +(member: (String, String)): TSInterface =
-      interface + (member._1 -> TSLiteralString(member._2))
     def ++(newMembers: Iterable[(String, TypescriptType)]): TSInterface =
       interface.copy(members = interface.members ++ newMembers)
     def -(member: String): TSInterface =
@@ -41,8 +39,6 @@ package object dsl {
 
   implicit class TSITypeDSL[T](val tsiType: TSIType[T]) extends AnyVal {
     def +(member: (String, TypescriptType)): TSIType[T] =
-      TSIType(tsiType.get + member)
-    def +(member: (String, String)): TSIType[T] =
       TSIType(tsiType.get + member)
     def ++(newMembers: Seq[(String, TypescriptType)]): TSIType[T] =
       TSIType(tsiType.get ++ newMembers)

--- a/src/sbt-test/plugin/simple/build.sbt
+++ b/src/sbt-test/plugin/simple/build.sbt
@@ -4,5 +4,5 @@ lazy val root = (project in file("."))
   .enablePlugins(nl.codestar.scala.ts.plugin.TypescriptGenPlugin)
   .settings(
     version := "0.1",
-    scalaVersion := "2.12.6"
+    scalaVersion := "2.13.0-RC1"
   )

--- a/src/sbt-test/plugin/simple/project/build.properties
+++ b/src/sbt-test/plugin/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.2.8

--- a/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
+++ b/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
@@ -31,6 +31,18 @@ class MacroTests extends FlatSpec with Matchers with DefaultTSTypes {
     case class Bar(bar: Int)    extends FooOrBar
 
     import nl.codestar.scalatsi.dsl._
+    implicit val tsFoo = TSType.fromCaseClass[Foo]
+    implicit val tsBar = TSType.fromCaseClass[Bar]
+
+    TSType.fromSealed[FooOrBar] shouldBe TSType.alias("FooOrBar", TSTypeReference("IFoo") | TSTypeReference("IBar"))
+  }
+
+  it should "handle sealed abstract classes" in {
+    sealed abstract class FooOrBar(tpe: String)
+    case class Foo(foo: String) extends FooOrBar("Foo")
+    case class Bar(bar: Int)    extends FooOrBar("Bar")
+
+    import nl.codestar.scalatsi.dsl._
     implicit val tsFoo = TSType.fromCaseClass[Foo] + ("type" -> "Foo")
     implicit val tsBar = TSType.fromCaseClass[Bar] + ("type" -> "Bar")
 

--- a/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
+++ b/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
@@ -53,4 +53,11 @@ class MacroTests extends FlatSpec with Matchers with DefaultTSTypes {
        TSIType.fromCaseClass[B]
     }""".stripMargin shouldNot compile
   }
+
+  it should "handle sealed traits" in {
+    sealed trait AOrB
+    case class A(tag: "A", foo: String) extends AOrB
+    case class B(tag: "B", bar: String) extends AOrB
+
+  }
 }

--- a/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
+++ b/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
@@ -26,12 +26,20 @@ class MacroTests extends FlatSpec with Matchers with DefaultTSTypes {
   }
 
   it should "handle sealed traits" in {
-    sealed trait AB
-    case class A(a: Int)    extends AB
-    case class B(b: String) extends AB
+    sealed trait FooOrBar
+    case class Foo(foo: String) extends FooOrBar
+    case class Bar(bar: Int)    extends FooOrBar
 
-    // implicit val abType: TSType[AB] = ???
-    pending
+    import nl.codestar.scalatsi.dsl._
+    implicit val tsFoo = TSType.fromCaseClass[Foo] + ("type" -> "Foo")
+    implicit val tsBar = TSType.fromCaseClass[Bar] + ("type" -> "Bar")
+
+    implicit val tsFooOrBar = TSType.fromSealedTrait[FooOrBar]
+
+    tsFoo.get shouldBe TSType.interface("IFoo", "foo" -> TSString, "type" -> TSLiteralString("Foo"))
+    tsFoo.get shouldBe TSType.interface("IBar", "bar" -> TSNumber, "type" -> TSLiteralString("Bar"))
+
+    tsFooOrBar shouldBe TSType.alias("FooOrBar", TSExternalName("Foo") | TSExternalName("Bar"))
   }
 
   it should "handle recursive definitions" in {
@@ -52,12 +60,5 @@ class MacroTests extends FlatSpec with Matchers with DefaultTSTypes {
        case class B(a: A)
        TSIType.fromCaseClass[B]
     }""".stripMargin shouldNot compile
-  }
-
-  it should "handle sealed traits" in {
-    sealed trait AOrB
-    case class A(tag: "A", foo: String) extends AOrB
-    case class B(tag: "B", bar: String) extends AOrB
-
   }
 }

--- a/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
+++ b/src/test/scala/nl/codestar/scalatsi/MacroTests.scala
@@ -57,11 +57,11 @@ class MacroTests extends FlatSpec with Matchers with DefaultTSTypes {
 
   it should "handle sealed traits with recursive definitions" in {
     sealed trait LinkedList
-    case object Nil extends LinkedList
-    case class Node(value: Int, next: LinkedList = Nil)
+    case object Nil                                     extends LinkedList
+    case class Node(value: Int, next: LinkedList = Nil) extends LinkedList
 
     implicit val nilType: TSType[Nil.type] = TSType(TSNull)
-    implicit val llType: TSType[Node]      = TSType(TSNull | TSTypeReference("ILinkedList"))
+    implicit val llType: TSType[Node]      = TSType.alias("INode", TSNull | TSTypeReference("ILinkedList"))
 
     TSType.fromSealed[LinkedList] shouldBe TSType.alias("LinkedList", TSNull | TSTypeReference("INode"))
   }


### PR DESCRIPTION
Solves #35

```
sealed trait AorB
case class A(foo: Int) extends AorB
case class B(bar: Int) extends AorB

implicit val tsA = TSType.fromCaseClass[A]
implicit val tsB = TSType.fromCaseClass[B]

implicit val tsAorB = TSType.fromSealed[AorB]
 ```

will produce 
```
interface IA {
  foo: number
}

interface IB {
  bar: number
}

type AorB = IA | IB
```