### PR TITLE
Added dependencies (and comma) necessary for codegen in 0.2.0-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys.scalacOptions
 
 lazy val commonSettings = Seq(
   organization := "nl.codestar",
-  version := "0.2.3-SNAPSHOT",
+  version := "0.2.0-SNAPSHOT",
   scalaVersion := "2.13.0",
   crossScalaVersions := Seq("2.12.8", "2.13.0"),
   compilerOptions,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys.scalacOptions
 
 lazy val commonSettings = Seq(
   organization := "nl.codestar",
-  version := "0.2.0-SNAPSHOT",
+  version := "0.2.3-SNAPSHOT",
   scalaVersion := "2.13.0",
   crossScalaVersions := Seq("2.12.8", "2.13.0"),
   compilerOptions,

--- a/plugin/src/main/twirl/generateTypescriptApplicationTemplate.scala.txt
+++ b/plugin/src/main/twirl/generateTypescriptApplicationTemplate.scala.txt
@@ -5,18 +5,20 @@ package nl.codestar.scalatsi.generator
 import _root_.nl.codestar.scalatsi.TSNamedType
 import _root_.nl.codestar.scalatsi.TypescriptType.TypescriptNamedType
 import _root_.java.io.File
+import _root_.nl.codestar.scalatsi.TypescriptType._
+import _root_.nl.codestar.scalatsi.TSType
 
 /** User imports */
 @for(imp <- imports) {
 import @imp
 }
 
-object ApplicationTypescriptGeneration {
+object ApplicationTypescriptGeneration extends _root_.nl.codestar.scalatsi.DefaultTSTypes {
 
   // If you get a generator or implicit not found error here, make sure you have defined a TSType[T] implicit and imported it
   val toOutput: Seq[TypescriptNamedType] = Seq(
     @for(userClass <- classes) {
-      TSNamedType.getOrGenerate[@userClass].get
+      TSNamedType.getOrGenerate[@userClass].get,
     }
   )
 


### PR DESCRIPTION
Upgrading from version 0.1.3 to 0.2.0-SNAPSHOT did not work for me, as (presumably) the generated `Seq` seemed to be missing commas, and there seemed to be types missing. Here is a configuration that works for me locally.