### PR TITLE
Use literal string in targetfile

### DIFF
--- a/plugin/src/main/twirl/generateTypescriptApplicationTemplate.scala.txt
+++ b/plugin/src/main/twirl/generateTypescriptApplicationTemplate.scala.txt
@@ -23,7 +23,7 @@ object ApplicationTypescriptGeneration extends _root_.nl.codestar.scalatsi.Defau
   )
 
   val options = _root_.nl.codestar.scalatsi.output.OutputOptions(
-    targetFile = new File("@targetFile")
+    targetFile = new File("""@targetFile""") // Warning: always use literal string here for windows paths with \
   )
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
For Windows with paths containing \ 
fixes #55